### PR TITLE
Add NIRCam grism time series wavecal workaround notebook

### DIFF
--- a/NIRCam_grism_time_series/nircam_grism_tso_wavecal_workaround.ipynb
+++ b/NIRCam_grism_time_series/nircam_grism_tso_wavecal_workaround.ipynb
@@ -1,0 +1,246 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3e7b21e8",
+   "metadata": {},
+   "source": [
+    "## Reprocess NIRCam Grism TSO data with new wavelength calibration reference file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ab03d54",
+   "metadata": {},
+   "source": [
+    "Created by B. Hilbert, 26 July 2023."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4d61c52-d560-44ee-aadf-53f05850f343",
+   "metadata": {},
+   "source": [
+    "This notebook downloads an example NIRCam grism time series file and runs the stage 2 and 3 calibration pipelines on the file. This is the procedure you would follow to reprocess your data if new wavelength calibration reference files become available. (The wavelength calibration reference files are called \"specwcs\" in CRDS.\n",
+    "\n",
+    "Following this example, you can reprocess your time series data when new specwcs reference files become available in CRDS."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d19174d",
+   "metadata": {},
+   "source": [
+    "<span style=\"color:red\">Note that when new reference files become available in CRDS, all data to which those reference files apply will generally be reprocessed using the new reference files within several weeks, and the products in MAST will be updated. But if you wish to reprocess the data yourself, this notebook outlines the method to do that.</span>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f439434-7dbb-4c00-8d0e-5088ca990521",
+   "metadata": {},
+   "source": [
+    "Define function to download a named file via the MAST API. The function includes authentication logic, but this example uses public data, so no MAST API token is required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ad635cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glob import glob\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "172af7c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jwst.pipeline.calwebb_spec2 import Spec2Pipeline\n",
+    "from jwst.pipeline.calwebb_tso3 import Tso3Pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aad5c5fc-3f6a-4226-9857-ea8037664e83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_jwst_file(name, mast_api_token=None):\n",
+    "    \"\"\"Retrieve a JWST data file from MAST archive.\"\"\"\n",
+    "    mast_url = \"https://mast.stsci.edu/api/v0.1/Download/file\"\n",
+    "    params = dict(uri=f\"mast:JWST/product/{name}\")\n",
+    "    if mast_api_token:\n",
+    "        headers = dict(Authorization=f\"token {get_mast_api_token()}\")\n",
+    "    else:\n",
+    "        headers = {}\n",
+    "    r = requests.get(mast_url, params=params, headers=headers, stream=True)\n",
+    "    r.raise_for_status()\n",
+    "    with open(name, \"wb\") as fobj:\n",
+    "        for chunk in r.iter_content(chunk_size=1024000):\n",
+    "            fobj.write(chunk)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "962c5623-88d0-4516-99e8-e22b4c9c5142",
+   "metadata": {},
+   "source": [
+    "List of filenames for a program that contains an example Grim TSO observation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96d6979d-5ff2-4d04-839b-3c49bc491f2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_tso_file = 'jw01068007001_03103_00001-seg001_nrcalong_rateints.fits'\n",
+    "level2_asn_file = 'jw01068-o007_20230626t065143_tso-spec2_00001_asn.json'\n",
+    "level3_asn_file = 'jw01068-o007_20230626t065143_tso3_00001_asn.json'\n",
+    "files = [example_tso_file, level2_asn_file, level3_asn_file]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32eca3fb",
+   "metadata": {},
+   "source": [
+    "Download example files from MAST"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ea00751-8671-4b8c-9e7c-f43cf3b4994e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for file in files:\n",
+    "    print(f'Downloading {file}')\n",
+    "    get_jwst_file(file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8792228",
+   "metadata": {},
+   "source": [
+    "Confirm that the files were downloaded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "844e1ffc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorted(glob('jw01068*'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0188bd2e",
+   "metadata": {},
+   "source": [
+    "Run the stage 2 pipeline. The new specwcs files will be automatically downloaded and used in the assign_wcs step. The name of this specwcs file is be given in the line below that contains the string: \"Prefetch for SPECWCS reference file\".\n",
+    "\n",
+    "We run the pipeline using the stage 2 association file, which lists the rateints file within it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "975f8fa3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "level2 = Spec2Pipeline.call(level2_asn_file, save_results=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5571b92",
+   "metadata": {},
+   "source": [
+    "The stage 2 pipeline saved the new calints and x1dints files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a49d36b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorted(glob('jw01068*'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abc832cb",
+   "metadata": {},
+   "source": [
+    "Run the stage 3 pipeline. The input to the pipeline is the stage 3 association file, which lists the calints file within it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8aa215c",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "level3 = Tso3Pipeline.call(level3_asn_file, save_results=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35c7877f",
+   "metadata": {},
+   "source": [
+    "The stage 3 pipeline saved updated versions of the crfints, median, x1dints, and whtlt files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d91548b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorted(glob('jw01068*'))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "jwst-3.9",
+   "language": "python",
+   "name": "jwst-3.9"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a very basic notebook that shows the user how to run the spec2 and tso3 pipelines in order to reprocess data when new specwcs files are available. 

The notebook assumes that the new reference files are in CRDS, and that they will be downloaded and used when the pipeline is called. There is no manual specification of the reference file names in the pipeline calls.

Corresponds to the single NIRCam grism time series issue on the "Known Issues with JWST Data Products" page.