### PR TITLE
Add a workflow for deprecating notebooks and a codeowners file for reviews

### DIFF
--- a/CODEOWNERS.txt
+++ b/CODEOWNERS.txt
@@ -1,0 +1,15 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence
+*   @sosey
+
+/general_issues/ @sosey
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+/MIRI/   @skendrew
+/NIRCam_grism_time_series/  @bhilbert4
+/NIRISS_SOSS/   @Rplesha    @tbainesUA
+/NIRSPEC_Fixed_Slit/    @melanieclarke  @PatrickOgle
+/NIRSPEC_General/   @melanieclarke  @PatrickOgle
+/NIRSPEC_IFU/   @melanieclarke  @PatrickOgle
+/NIRSPEC_MOS/   @melanieclarke  @PatrickOgle

--- a/README.md
+++ b/README.md
@@ -16,18 +16,19 @@ It takes a few weeks to integrate a new calibration pipeline build into a full S
 
 ## Deprecation of Notebooks
 
-If JWST DMS infrastructure has been updated, and the workarounds in a specific notebook are no longer neccessary or recommended, then the notebook will be deprecated. The process for deprecating a notebook includes the following:
+Once JWST DMS infrastructure has been updated, and the workarounds in a specific notebook are no longer neccessary or recommended, then the notebook will be deprecated. The process for deprecating a notebook includes the following:
 
-*  Ensure that any DMS software or reference file updates have been released publicly
-*  Update the notebook to include a new cell at the top of the notebook which contains:
-    * A sentence in large font explaining that the workaround is no longer needed and the notebook is deprecated
-    * The calibration software version that contains the fix
-    * The CRDS context that should be used
-    * A timeline that reprocessing will occur that will update the files in the JWST Archive
- 
+*  Determine what calibration software version and CRDS context mitigated the issue worked around in the notebook
+*  Determine the DATE when DMS operations first began generating data products that no longer require the workaround described in the notebook
+*  Insert a new cell at th etop of the notebook with a deprecation comment in a large font. The default deprecation comment is the following:
+
+
+>This notebook is deprecated. Data products generated with calibration software version x.y.z or later, and CRDS context jwst_xxxx.pmap or later, no longer require this workaround. Data products in MAST created after DATE no longer require this workaround. To check creation dates for files in MAST, substitute your program ID for 2288 at the end of this URL:
+>
+>https://mast.stsci.edu/search/ui/#/jwst/results?select_cols=fileSetName,dataset,cal_ver,crds_ctx,date&program_id=2288
+
 
 *  Submit a PR that includes the updated files
-*  Make sure that the JDOX table and information has been updated appropriately
-*  After PR acceptance, the notebook should stay available for a period of 1 month, or until after reprocessing in the Archive as completed,  so that folks can still view it easily 
-    * After the specified time, create and submit a PR that removes the notebook from the repository
+*  Make sure that the JDOX Known Issues table entry has been updated appropriately
+*  After all affected products in MAST have been reprocessed, or after 3 months, whichever is longer, submit a PR that removes the notebook from the repository
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once JWST DMS infrastructure has been updated, and the workarounds in a specific
 
 *  Determine what calibration software version and CRDS context mitigated the issue worked around in the notebook
 *  Determine the DATE when DMS operations first began generating data products that no longer require the workaround described in the notebook
-*  Insert a new cell at th etop of the notebook with a deprecation comment in a large font. The default deprecation comment is the following:
+*  Insert a new cell at the top of the notebook with a deprecation comment in a large font. The default deprecation comment is the following:
 
 
 >This notebook is deprecated. Data products generated with calibration software version x.y.z or later, and CRDS context jwst_xxxx.pmap or later, no longer require this workaround. Data products in MAST created after DATE no longer require this workaround. To check creation dates for files in MAST, substitute your program ID for 2288 at the end of this URL:
@@ -30,5 +30,9 @@ Once JWST DMS infrastructure has been updated, and the workarounds in a specific
 
 *  Submit a PR that includes the updated files
 *  Make sure that the JDOX Known Issues table entry has been updated appropriately
-*  After all affected products in MAST have been reprocessed, or after 3 months, whichever is longer, submit a PR that removes the notebook from the repository
+*  Make sure that any related calibration pipeline documentation has been updated
+*  After all affected products in MAST have been reprocessed, or after 3 months, whichever is 
+longer, submit a PR that removes the notebook from the repository
+*  Review any files being deprecated to assess whether an updated copy of the notebook should be submitted to the JDAT repository for long term use and maintenance.  See https://github.com/spacetelescope/jdat_notebooks
+
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,22 @@ Some issues can be fixed by reprocessing data on your computer, using the latest
 It takes a few weeks to integrate a new calibration pipeline build into a full Science & Operations Center (S&OC) software build, test the S&OC build, fix subsystem interface issues, and finally install the S&OC build in operations. After that, fixes in the new pipeline software and/or reference data will be reflected in new (or replaced) products in MAST. 
 
 [The software vs DMS build table in the JWST pipeline repository](https://github.com/spacetelescope/jwst) indicates when jwst builds were released, which reference data (CRDS) context they were tested with, and when the was first used in S&OC operations. Some JWST releases (particularly S&OC release candidates) are never installed in operations. That page also provides detailed instructions on how to create a fresh conda environment, install the version of the pipeline you would like to use, and how to configure the CRDS environment that is appropriate for that release.
+
+
+## Deprecation of Notebooks
+
+If JWST DMS infrastructure has been updated, and the workarounds in a specific notebook are no longer neccessary or recommended, then the notebook will be deprecated. The process for deprecating a notebook includes the following:
+
+*  Ensure that any DMS software or reference file updates have been released publicly
+*  Update the notebook to include a new cell at the top of the notebook which contains:
+    * A sentence in large font explaining that the workaround is no longer needed and the notebook is deprecated
+    * The calibration software version that contains the fix
+    * The CRDS context that should be used
+    * A timeline that reprocessing will occur that will update the files in the JWST Archive
+ 
+
+*  Submit a PR that includes the updated files
+*  Make sure that the JDOX table and information has been updated appropriately
+*  After PR acceptance, the notebook should stay available for a period of 1 month, or until after reprocessing in the Archive as completed,  so that folks can still view it easily 
+    * After the specified time, create and submit a PR that removes the notebook from the repository
+


### PR DESCRIPTION
This adds a codeowners file so that teams responsible for specific notebooks will be notified for PR review.

This also adds a suggested workflow for deprecating notebooks that are no longer needed because of updated to DMS.