### PR TITLE
Deprecating DO_NOT_USE notebook for SOSS

### DIFF
--- a/NIRISS_SOSS/do_not_use_workaround.ipynb
+++ b/NIRISS_SOSS/do_not_use_workaround.ipynb
@@ -14,7 +14,15 @@
     "# Turning off `DO_NOT_USE` pixels in the JWST pipeline\n",
     "\n",
     "**Author**: Néstor Espinoza (Assistant Astronomer; Mission Scientist for Exoplanet Science) <br>\n",
-    "**Last Updated**: July 27, 2023<br>"
+    "**Last Updated**: February 27, 2024<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-danger\"> <font size=\"4\"><b>Important:</b> The problems described below have been solved for versions of the pipeline 1.12.5 and up, for CRDS context versions jwst_1193.pmap and above. Because of this, <b>the workarounds described below and this current notebook are to be considered deprecated.</b>\n",
+    "</font> </div>"
    ]
   },
   {


### PR DESCRIPTION
Hi everyone,

 As of a few weeks ago, most of the DO_NOT_USE problems have been solved for SOSS. Writing this PR to deprecate the notebook I wrote to showcase a workaround for this, as everything is working back to normal again:

<img width="1036" alt="Screen Shot 2024-02-27 at 5 49 19 PM" src="https://github.com/spacetelescope/jwst-caveat-examples/assets/2046682/0a7c6f18-9615-43a6-b430-7a4d84f826ef">

N.