### PR TITLE
Add kayli as the nirspec reviewer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 /Pure_Parallels/  @goudfroo @bhilbert4
 /NIRCam_grism_time_series/  @bhilbert4
 /NIRISS_SOSS/   @Rplesha    @tbainesUA
-/NIRSPEC_Fixed_Slit/    @hayescr  @PatrickOgle
-/NIRSPEC_General/   @hayescr  @PatrickOgle
-/NIRSPEC_IFU/   @hayescr  @PatrickOgle
-/NIRSPEC_MOS/   @hayescr  @PatrickOgle
+/NIRSPEC_Fixed_Slit/    @hayescr  @kglidic
+/NIRSPEC_General/   @hayescr  @kglidic
+/NIRSPEC_IFU/   @hayescr  @kglidic
+/NIRSPEC_MOS/   @hayescr  @kglidic


### PR DESCRIPTION
this updates the codeowners file to exchange patrick for kayli as a default reviewer